### PR TITLE
Fix permutation mapper

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/mappers/permutation.py
+++ b/applications/CoSimulationApplication/python_scripts/mappers/permutation.py
@@ -68,4 +68,12 @@ class MapperPermutation(object):
 
         for node_from, node_to in zip(model_part_from.Nodes, model_part_to.Nodes):
             value = node_from.GetSolutionStepValue(var_from)
+
+            if var_from.Type() == 'Double':
+                pass
+            elif var_from.Type() == 'Array':
+                value = list(np.array(value)[self.permutation])
+            else:
+                raise NotImplementedError(f'Mapping not yet implemented for Variable of Type {var_from.Type()}.')
+
             node_to.SetSolutionStepValue(var_to, 0, value)

--- a/applications/CoSimulationApplication/tests/mappers/test_permutation.py
+++ b/applications/CoSimulationApplication/tests/mappers/test_permutation.py
@@ -6,22 +6,6 @@ import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tool
 import numpy as np
 import os
 
-import time
-from contextlib import contextmanager
-@contextmanager
-def timer(name=None, t=0, n=0, ms=False):
-    startTime = time.time()
-    yield
-    elapsedTime = time.time() - startTime
-    if ms:
-        s = '\n' * n + '\t' * t + f'{elapsedTime * 1000:.2f}ms'
-        s.replace(',', ' ')
-    else:
-        s = '\n' * n + '\t' * t + f'{elapsedTime:.1f}s'
-    if name is not None:
-        s += f' - {name}'
-    s += '\n' * n
-    print(s)
 
 class TestMapperPermutation(KratosUnittest.TestCase):
     def test_mapper_permutation(self):
@@ -80,7 +64,7 @@ class TestMapperPermutation(KratosUnittest.TestCase):
 
             for i in range(10):
                 node = model_part_from.CreateNewNode(i, i * 1., i * 2., i * 3.)
-                node.SetSolutionStepValue(var, 0, [node.X ** 2, node.Y ** 2, node.Z ** 2])
+                node.SetSolutionStepValue(var, 0, list(np.random.rand(3)))
 
             mapper = cs_tools.CreateInstance(parameters['mapper'])
             model_part_to = mapper.Initialize(model_part_from, forward=True)
@@ -88,7 +72,7 @@ class TestMapperPermutation(KratosUnittest.TestCase):
 
             for node_from, node_to in zip(model_part_from.Nodes, model_part_to.Nodes):
                 val_from = node_from.GetSolutionStepValue(var)
-                val_from = list(np.array(val_from)[[2, 0, 1]])
+                val_from = list(np.array(val_from)[mapper.permutation])
                 val_to = node_to.GetSolutionStepValue(var)
                 self.assertListEqual(val_from, val_to)
 

--- a/applications/CoSimulationApplication/tests/mappers/test_permutation.py
+++ b/applications/CoSimulationApplication/tests/mappers/test_permutation.py
@@ -51,7 +51,7 @@ class TestMapperPermutation(KratosUnittest.TestCase):
             node = model_part_from.Nodes[0]
             self.assertListEqual([node.X, node.Y, node.Z], [0., 1., 2.])
 
-        # check if method __call__ works
+        # check if method __call__ works for Double Variable
         if True:
             var = vars(KM)["TEMPERATURE"]
             model = cs_data_structure.Model()
@@ -70,6 +70,27 @@ class TestMapperPermutation(KratosUnittest.TestCase):
                 val_from = node_from.GetSolutionStepValue(var)
                 val_to = node_to.GetSolutionStepValue(var)
                 self.assertEqual(val_from, val_to)
+
+        # check if method __call__ works for Array Variable
+        if True:
+            var = vars(KM)["DISPLACEMENT"]
+            model = cs_data_structure.Model()
+            model_part_from = model.CreateModelPart('wall_from')
+            model_part_from.AddNodalSolutionStepVariable(var)
+
+            for i in range(10):
+                node = model_part_from.CreateNewNode(i, i * 1., i * 2., i * 3.)
+                node.SetSolutionStepValue(var, 0, [node.X ** 2, node.Y ** 2, node.Z ** 2])
+
+            mapper = cs_tools.CreateInstance(parameters['mapper'])
+            model_part_to = mapper.Initialize(model_part_from, forward=True)
+            mapper((model_part_from, var), (model_part_to, var))
+
+            for node_from, node_to in zip(model_part_from.Nodes, model_part_to.Nodes):
+                val_from = node_from.GetSolutionStepValue(var)
+                val_from = list(np.array(val_from)[[2, 0, 1]])
+                val_to = node_to.GetSolutionStepValue(var)
+                self.assertListEqual(val_from, val_to)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The permutation mapper worked fine for scalar variables, but for vector variables not only the coordinates but also the historical variable's components must be swapped. This functionality was added.